### PR TITLE
Bit-field only available in gcc

### DIFF
--- a/spit/positions.h
+++ b/spit/positions.h
@@ -12,8 +12,8 @@ typedef struct {
   unsigned short seed;           // 2
   unsigned short q;              // 2
   char  action;                  // 1: 'R' or 'W'
-  char  success:4;               // 0.5
-  char  verify:4;                // 0.5
+  unsigned int  success:4;               // 0.5
+  unsigned int  verify:4;                // 0.5
 } positionType;
 
 typedef struct {


### PR DESCRIPTION
`/tmp/stutools/spit/positions.h:15:3: error: type of bit-field ‘success’ is a GCC extension [-Werror=pedantic]`
   `char  success:4;               // 0.5`
   `^`
`/tmp/stutools/spit/positions.h:16:3: error: type of bit-field ‘verify’ is a GCC extension [-Werror=pedantic]`
   `char  verify:4;                // 0.5`
   `^`
