### PR TITLE
Set utils cmake min to 3.0

### DIFF
--- a/utils/Version.cmake
+++ b/utils/Version.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.0)
 
 execute_process(COMMAND git rev-parse HEAD
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
This fixes a deprecation warning from cmake on debian sid.