### PR TITLE
Use git to determine the version of spit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Object files
 *.o
+spit/spit-version.h

--- a/spit/CMakeLists.txt
+++ b/spit/CMakeLists.txt
@@ -5,7 +5,22 @@ get_directory_property(hasParent PARENT_DIRECTORY)
 if(NOT hasParent)
   include( ${CMAKE_CURRENT_SOURCE_DIR}/../utils/Version.cmake)
 endif()
-  
+
+execute_process(COMMAND git describe --tags
+    OUTPUT_VARIABLE GIT_REV
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# This is used if there is no tag or the working dir is not a git repo.
+if("${GIT_REV}" STREQUAL "")
+    set(GIT_REV "1.1-unofficial")
+endif()
+
+set(VERSION "const char* SPIT_VERSION=\"${GIT_REV}\";")
+
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/spit-version.h)
+    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/spit-version.h "${VERSION}")
+endif()
 
 include (CTest)
 
@@ -17,7 +32,7 @@ set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Werror -Wextra -Wall -pedantic --std=gn
 
 add_library(spitlib STATIC positions.c devices.c utils.c diskStats.c logSpeed.c aioRequests.c jobType.c histogram.c spitfuzz.c blockVerify.c lengths.c workQueue.c list.c latency.c numList.c procDiskStats.c mapVoid.c)
 
-add_executable(spit spit.c)
+add_executable(spit spit.c spit-version.h)
 target_link_libraries(spit spitlib m aio pthread numa)
 
 add_executable(snackrec netrec.c transfer.h)

--- a/spit/spit.c
+++ b/spit/spit.c
@@ -3,13 +3,10 @@
 #define _GNU_SOURCE
 
 #include "jobType.h"
+#include "spit-version.h"
 #include <signal.h>
 #include <math.h>
 #include <linux/limits.h>
-
-#ifndef VERSION
-#define VERSION __TIMESTAMP__
-#endif
 
 /**
  * spit.c
@@ -837,7 +834,7 @@ int doReport(const double runseconds, size_t maxSizeInBytes, const size_t cacheS
   fprintf(stdout, " OS: %s\n", os);
   if (os) free(os);
   fprintf(stdout, " RAM: %.0lf GiB (%.1lf GiB)\n", TOGiB(totalRAM()), TOGiB(ramBytesForPositions));
-  fprintf(stdout, " stutools: %s\n", VERSION);
+  fprintf(stdout, " stutools: %s\n", SPIT_VERSION);
   fprintf(stdout, "\n\n");
 
   diskStatType d;
@@ -1120,7 +1117,7 @@ int main(int argc, char *argv[])
 
   double starttime = timedouble();
 
-  fprintf(stderr,"*info* spit %s %s (Stu's powerful I/O tester)\n", argv[0], VERSION);
+  fprintf(stderr,"*info* spit %s %s (Stu's powerful I/O tester)\n", argv[0], SPIT_VERSION);
 
   if (swapTotal() > 0) {
     fprintf(stderr,"*warning* spit needs swap to be off for consistent numbers. `sudo swapoff -a`\n");


### PR DESCRIPTION
This uses `git describe -tags` to determine a version string for spit. debuild does not like the use of `VERSION=__TIMESTAMP__` in spit.c because it creates an unreproduceable build.

`git describe --tags` will produce a string consisting of the most recent tag for the branch and a suffix that describes commits since that tag.

I'm not sure how should correlate with the logic in utils/Version.cmake.
